### PR TITLE
fix(ci): specify semantic release version that is compatible with node 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_NPM_TOKEN }}
-      run: npx semantic-release
+      run: npx semantic-release@22


### PR DESCRIPTION
semantic-release [version 23](https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0) includes the following breaking change:
* support for node v18 has been dropped and the minimum for v20 is now v20.8.1

This pins the release workflow to version 22 until we move away from node 18.