### PR TITLE
build: Remove codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,3 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3


### PR DESCRIPTION
Update codecov to the latest version and start using the org-wide token for uploads.

See https://github.com/openedx/wg-frontend/issues/179
